### PR TITLE
:construction: Deploy the backend to k8s, refs DP-424

### DIFF
--- a/buildspecs/egs.yaml
+++ b/buildspecs/egs.yaml
@@ -1,0 +1,50 @@
+version: 0.2
+
+env:
+  parameter-store:
+    build_ssh_key: 'build-ssh-key-secure'
+
+phases:
+  install:
+    runtime-versions:
+      docker: 19
+  pre_build:
+    commands:
+      - echo Logging in to Amazon ECR...
+      - aws --version
+      - docker --version
+      - $(aws ecr get-login --region $AWS_DEFAULT_REGION --no-include-email)
+      - REPOSITORY_URI=017964463726.dkr.ecr.us-west-1.amazonaws.com/egs-legacy-backend
+      - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
+      - IMAGE_TAG=${COMMIT_HASH:=latest}
+  build:
+    commands:
+      - echo Build started on `date`
+      - echo Building the Docker image...
+      - echo building image with tag ${IMAGE_TAG}
+      - mkdir -p ~/.ssh
+      - echo "$build_ssh_key" > ~/.ssh/id_rsa
+      - chmod 600 ~/.ssh/id_rsa
+      - DOCKER_BUILDKIT=1 docker build -f Dockerfile --build-arg STAGE="staging" --ssh github="$HOME/.ssh/id_rsa" --tag $REPOSITORY_URI:latest .
+      - docker tag $REPOSITORY_URI:latest $REPOSITORY_URI:$IMAGE_TAG
+  post_build:
+    commands:
+      - echo Build completed on `date`
+      - echo Pushing the Docker images...
+      - docker push $REPOSITORY_URI:latest
+      - docker push $REPOSITORY_URI:$IMAGE_TAG
+      - echo Writing image definitions file...
+      - echo "Setting Environment Variables related to AWS CLI for Kube Config Setup"
+      - CREDENTIALS=$(aws sts assume-role --role-arn "arn:aws:iam::017964463726:role/terraform-eks-dfp-cluster" --role-session-name codebuild-kubectl --duration-seconds 900)
+      - export AWS_ACCESS_KEY_ID="$(echo ${CREDENTIALS} | jq -r '.Credentials.AccessKeyId')"
+      - export AWS_SECRET_ACCESS_KEY="$(echo ${CREDENTIALS} | jq -r '.Credentials.SecretAccessKey')"
+      - export AWS_SESSION_TOKEN="$(echo ${CREDENTIALS} | jq -r '.Credentials.SessionToken')"
+      - export AWS_EXPIRATION=$(echo ${CREDENTIALS} | jq -r '.Credentials.Expiration')
+      - export KUBECONFIG=$HOME/.kube/config
+      # Setup kubectl with our EKS Cluster
+      - aws eks --region us-west-1 update-kubeconfig --name dfp-cluster
+      - kubectl apply -f k8s-manifests/deployments/egs-legacy-backend.yaml
+      - kubectl set image -n egs-legacy-staging deploy/egs-legacy-backend egs-legacy-backend=$REPOSITORY_URI:$IMAGE_TAG
+      - printf '[{"name":"hello-world","imageUri":"%s"}]' $REPOSITORY_URI:$IMAGE_TAG > imagedefinitions.json
+artifacts:
+  files: imagedefinitions.json

--- a/k8s-manifests/configmaps/env.yaml
+++ b/k8s-manifests/configmaps/env.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: egs-legacy-staging-config
+    namespace : egs-legacy-staging
+data:
+    STAGE: staging

--- a/k8s-manifests/deployments/egs-legacy-backend.yaml
+++ b/k8s-manifests/deployments/egs-legacy-backend.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: egs-legacy-backend
+  namespace: egs-legacy-staging
+  labels:
+    app: egs-legacy-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: egs-legacy-backend
+  template:
+    metadata:
+      labels:
+        app: egs-legacy-backend
+    spec:
+      containers:
+      - name: egs-legacy-backend
+        image: 017964463726.dkr.ecr.us-west-1.amazonaws.com/egs-legacy-backend:latest
+        resources:
+          requests:
+            memory: "500Mi"
+            cpu: "250m"
+          limits:
+            memory: "1Gi"
+            cpu: "500m"
+        ports:
+        - containerPort: 3000
+        envFrom:
+          - secretRef:
+              name: egs-legacy-staging-secret
+          - configMapRef:
+              name: egs-legacy-staging-config

--- a/k8s-manifests/hpa/pod-autoscaler.yaml
+++ b/k8s-manifests/hpa/pod-autoscaler.yaml
@@ -1,0 +1,21 @@
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: egs-legacy-backend-hpa
+  namespace: egs-legacy-staging
+  labels:
+    app: egs-legacy-backend
+spec:
+  minReplicas: 1
+  maxReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: egs-legacy-backend
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 60


### PR DESCRIPTION
Also fixes DP-428 Continuous Delivery.
Note the backend is actually just a worker pushing to the database and
to caching, but it doesn't expose real services.
Also the backend pod is deployed, but crashes at runtime as it's
expected few dependencies:
- MariaDB database
- Redis caching
- geth node

This will be addressed one after the other in follow up pull requests.

Secrets and config maps got deployed manually via:
```sh
kubectl --namespace egs-legacy-staging \
create secret generic egs-legacy-staging-secret
kubectl create -f k8s-manifests/configmaps/env.yaml
```